### PR TITLE
Reset background fade when image changes

### DIFF
--- a/UpDown/src/StoryScenePanel.java
+++ b/UpDown/src/StoryScenePanel.java
@@ -66,15 +66,17 @@ public abstract class StoryScenePanel extends BaseScenePanel {
         
         if (moment.backgroundImagePath != null && !moment.backgroundImagePath.equals(currentBackgroundImagePath)) {
             currentBackgroundImagePath = moment.backgroundImagePath;
-            
+
             try {
                 backgroundImage = Toolkit.getDefaultToolkit().getImage(getClass().getResource(currentBackgroundImagePath));
             } catch (Exception e) {
                 backgroundImage = null;
             }
-        }
 
-        if (!backgroundFadedIn) {
+            backgroundFadedIn = false;
+            backgroundAlpha = 0f;
+            startBackgroundFadeIn();
+        } else if (!backgroundFadedIn) {
             startBackgroundFadeIn();
         }
 


### PR DESCRIPTION
## Summary
- reset background fade tracking whenever a new moment's background image is loaded
- always start the background fade-in after swapping images

## Testing
- `javac` compile all Java files

------
https://chatgpt.com/codex/tasks/task_e_684b279b28f0832f8060a848108d8e81